### PR TITLE
Add a thin wrapper around a successful morph lookup

### DIFF
--- a/timur/helpers/__init__.py
+++ b/timur/helpers/__init__.py
@@ -1,2 +1,2 @@
-from .helpers import load_alphabet
+from .helpers import Analysis
 from .helpers import load_lexicon

--- a/timur/helpers/helpers.py
+++ b/timur/helpers/helpers.py
@@ -1,35 +1,51 @@
 # -*- coding: utf-8 -*- 
 import pynini
 import re
-
-def load_alphabet(source, auto_singletons=True):
-    '''
-    Load symbols from source and add them to a symbol table.
-    '''
-    syms = pynini.SymbolTable()
-    syms.add_symbol("<epsilon>")
-    if auto_singletons:
-        for i in range(0,256):
-            symbol = chr(i)
-            if symbol.isprintable() and not symbol.isspace():
-                syms.add_symbol(symbol)
-    for symbol in source:
-        if isinstance(symbol, bytes):
-            symbol = symbol.decode("utf-8")
-        if symbol.startswith('#'):
-            continue
-        syms.add_symbol(symbol.strip())
-    return syms
+import json
 
 def load_lexicon(source, symbol_table):
+  '''
+  Load lexica entries from source interpreting them using a given symbol table.
+  '''
+  lex = pynini.Fst()
+  lex.set_input_symbols(symbol_table)
+  lex.set_output_symbols(symbol_table)
+  # longest match, prefer complex over simple symbols
+  tokenizer = re.compile("<[^>]*>|.", re.U)
+  for line in source:
+    lex = pynini.union(lex, pynini.acceptor(" ".join(tokenizer.findall(line.strip())), token_type=symbol_table))
+  return lex
+
+class Analysis:
+  '''
+  Analysis wrapper
+  '''
+
+  def __init__(self):
     '''
-    Load lexica entries from source interpreting them using a given symbol table.
+    Constructor
     '''
-    lex = pynini.Fst()
-    lex.set_input_symbols(symbol_table)
-    lex.set_output_symbols(symbol_table)
-    # longest match, prefer complex over simple symbols
-    tokenizer = re.compile("<[^>]*>|.", re.U)
-    for line in source:
-        lex = pynini.union(lex, pynini.acceptor(" ".join(tokenizer.findall(line.strip())), token_type=symbol_table))
-    return lex
+    self.query = ""
+    self.result = ""
+
+  @classmethod
+  def spur(cls, path):
+    '''
+    Create an analysis from a (successful) path
+    '''
+    a = cls()
+    upper = path[0].split(" ")
+    lower = path[1].split(" ")
+
+    for i,sym in enumerate(lower):
+      if sym != "<epsilon>":
+        a.query += sym
+      if upper[i] != "<epsilon>":
+        a.result += upper[i]
+    return a
+
+  def to_json(self):
+    '''
+    Serialize analysis as JSON
+    '''
+    return json.dumps(self.__dict__)

--- a/timur/scripts/timur.py
+++ b/timur/scripts/timur.py
@@ -10,6 +10,7 @@ import click
 import pynini
 
 from timur import fsts
+from timur import helpers
 
 def construct_any(symbol_table):
     '''
@@ -61,10 +62,8 @@ def lookup(strings, fst):
         items = timur.lookup(string)
         for item in items:
             click.echo("> Analysis")
-            istring = item[0].split(" ")
-            ostring = item[1].split(" ")
-            for i,sym in enumerate(istring):
-                click.echo("%s\t%s" % (istring[i], ostring[i]))
+            analysis = helpers.Analysis.spur(item)
+            click.echo(analysis.to_json())
 
 @cli.command(name="build")
 @click.argument('lexicon', type=click.File())


### PR DESCRIPTION
Right now, it only contains input and output. To be extended.