### PR TITLE
Fix the handling of the (new) origin marker 'prefnativ'

### DIFF
--- a/timur/data/suff_stems.txt
+++ b/timur/data/suff_stems.txt
@@ -1,7 +1,7 @@
 <Suff_Stems><simplex><nativ><deriv><V><Ge-Nom><NN><SUFF><base><nativ><NNeut/Sg_s>
 
 <Suff_Stems><prefderiv,simplex,suffderiv><frei,nativ><deriv><V>ung<epsilon>:s<NN><SUFF><kompos><nativ>
-<Suff_Stems><prefderiv,simplex,suffderiv><frei,nativ><deriv><V>ung<NN><SUFF><base><nativ><NFem-Deriv>
+<Suff_Stems><prefderiv,simplex,suffderiv><frei,nativ,prefnativ><deriv><V>ung<NN><SUFF><base><nativ><NFem-Deriv>
 <Suff_Stems><prefderiv,simplex,suffderiv><frei,nativ><deriv><V>ung<NN><SUFF><kompos><nativ>
 
 <Suff_Stems><prefderiv,simplex,suffderiv><frei,fremd,nativ><deriv><V>bar<ADJ><SUFF><base><nativ><Adj+>

--- a/timur/data/syms.txt
+++ b/timur/data/syms.txt
@@ -633,3 +633,5 @@ z	90
 <zu>    632
 <Ge>    633
 <prefnativ>	644
+<nativ,prefnativ>	645
+<frei,nativ,prefnativ>	646

--- a/timur/fsts/deko_fst.py
+++ b/timur/fsts/deko_fst.py
@@ -34,18 +34,11 @@ class DekoFst:
     # umlautung
     self.__umlautung = self.__construct_umlautung()
 
-    suff_filter_helper = pynini.compose(
-      self.__origin_filter,
-      pynini.compose(
-        self.__stem_type_filter,
-        pynini.compose(
-          self.__category_filter,
-          self.__umlautung,
-          )
-        )
-      ).optimize()
-    suff_phon = self.__construct_suff_phon()
-    self.__suff_filter = pynini.compose(suff_filter_helper, suff_phon).optimize()
+    # suffix phonology
+    self.__suff_phon = self.__construct_suff_phon()
+
+    # putting it all together
+    self.__suff_filter = (self.__origin_filter * self.__stem_type_filter * self.__category_filter * self.__umlautung * self.__suff_phon).optimize()
 
     #
     # prefix filter
@@ -80,13 +73,7 @@ class DekoFst:
     # imperative filter
     self.__imperative_filter = self.__construct_imperative_filter()
 
-    self.__infix_filter = pynini.compose(
-        self.__insert_ge,
-        pynini.compose(
-          self.__insert_zu,
-          self.__imperative_filter
-          )
-        ).optimize()
+    self.__infix_filter = (self.__insert_ge * self.__insert_zu * self.__imperative_filter).optimize()
 
     #
     # uplow
@@ -177,7 +164,7 @@ class DekoFst:
         self.__syms.stem_type_features
         ).closure().optimize()
 
-    filtering = self.__suff_stems_filter(["<nativ>", "<frei>", "<gebunden>", "<kurz>", "<lang>", "<fremd>", "<klassisch>", "<NSNeut_es_e>", "<NSFem_0_n>", "<NSFem_0_en>", "<NSMasc_es_e>", "<NSMasc_es_$e>", "<NSMasc-s/$sse>", "<NGeo-$er-NMasc_s_0>", "<NGeo-$er-Adj0-Up>", "<NGeo-$isch-Adj+>", "<NGeo-0-Name-Fem_0>", "<NGeo-0-Name-Masc_s>", "<NGeo-0-Name-Neut_s>", "<NGeo-a-Name-Fem_s>", "<NGeo-a-Name-Neut_s>", "<NGeo-aner-NMasc_s_0>", "<NGeo-aner-Adj0-Up>", "<NGeo-anisch-Adj+>", "<NGeo-e-NMasc_n_n>", "<NGeo-e-Name-Fem_0>", "<NGeo-e-Name-Neut_s>", "<NGeo-ei-Name-Fem_0>", "<NGeo-en-Name-Neut_s>", "<NGeo-er-NMasc_s_0>", "<NGeo-er-Adj0-Up>", "<NGeo-0-NMasc_s_0>", "<NGeo-0-Adj0-Up>", "<NGeo-erisch-Adj+>", "<NGeo-ese-NMasc_n_n>", "<NGeo-esisch-Adj+>", "<NGeo-ianer-NMasc_s_0>", "<NGeo-ianisch-Adj+>", "<NGeo-ien-Name-Neut_s>", "<NGeo-ier-NMasc_s_0>", "<NGeo-isch-Adj+>", "<NGeo-istan-Name-Neut_s>", "<NGeo-land-Name-Neut_s>", "<NGeo-ner-NMasc_s_0>", "<NGeo-ner-Adj0-Up>", "<NGeo-nisch-Adj+>"])
+    filtering = self.__suff_stems_filter(["<nativ>", "<prefnativ>", "<frei>", "<gebunden>", "<kurz>", "<lang>", "<fremd>", "<klassisch>", "<NSNeut_es_e>", "<NSFem_0_n>", "<NSFem_0_en>", "<NSMasc_es_e>", "<NSMasc_es_$e>", "<NSMasc-s/$sse>", "<NGeo-$er-NMasc_s_0>", "<NGeo-$er-Adj0-Up>", "<NGeo-$isch-Adj+>", "<NGeo-0-Name-Fem_0>", "<NGeo-0-Name-Masc_s>", "<NGeo-0-Name-Neut_s>", "<NGeo-a-Name-Fem_s>", "<NGeo-a-Name-Neut_s>", "<NGeo-aner-NMasc_s_0>", "<NGeo-aner-Adj0-Up>", "<NGeo-anisch-Adj+>", "<NGeo-e-NMasc_n_n>", "<NGeo-e-Name-Fem_0>", "<NGeo-e-Name-Neut_s>", "<NGeo-ei-Name-Fem_0>", "<NGeo-en-Name-Neut_s>", "<NGeo-er-NMasc_s_0>", "<NGeo-er-Adj0-Up>", "<NGeo-0-NMasc_s_0>", "<NGeo-0-Adj0-Up>", "<NGeo-erisch-Adj+>", "<NGeo-ese-NMasc_n_n>", "<NGeo-esisch-Adj+>", "<NGeo-ianer-NMasc_s_0>", "<NGeo-ianisch-Adj+>", "<NGeo-ien-Name-Neut_s>", "<NGeo-ier-NMasc_s_0>", "<NGeo-isch-Adj+>", "<NGeo-istan-Name-Neut_s>", "<NGeo-land-Name-Neut_s>", "<NGeo-ner-NMasc_s_0>", "<NGeo-ner-Adj0-Up>", "<NGeo-nisch-Adj+>"])
 
     return pynini.concat(
         pynini.concat(

--- a/timur/fsts/map_fst.py
+++ b/timur/fsts/map_fst.py
@@ -58,7 +58,8 @@ class MapFst:
     "<fremd,gebunden,lang>", "<frei,fremd,kurz>", "<frei,fremd,lang>", "<frei,gebunden>", 
     "<frei,gebunden,kurz,lang>", "<frei,gebunden,lang>", "<frei,lang>", "<klassisch,nativ>", 
     "<fremd,klassisch,nativ>", "<fremd,klassisch>", "<frei,nativ>", "<frei,fremd,nativ>", 
-    "<fremd,nativ>", "<komposit,prefderiv,simplex,suffderiv>", "<prefderiv,suffderiv>", 
+    "<fremd,nativ>","<nativ,prefnativ>","<frei,nativ,prefnativ>",
+    "<komposit,prefderiv,simplex,suffderiv>", "<prefderiv,suffderiv>", 
     "<komposit,prefderiv,simplex>", "<komposit,simplex,suffderiv>", "<komposit,simplex>", 
     "<prefderiv,simplex,suffderiv>", "<prefderiv,simplex>", "<simplex,suffderiv>"]
     disjunctive_feats = pynini.string_map(disjunctive_feat_list, input_token_type=syms.alphabet, output_token_type=syms.alphabet).project().optimize()

--- a/timur/fsts/timur_fst.py
+++ b/timur/fsts/timur_fst.py
@@ -159,7 +159,7 @@ class TimurFst:
         )
 
     defaults.ge_nom_stems_v.draw("target.dot", portrait=True)
-    bdk_stems = sublexica.bdk_stems | defaults.compound_stems_nn | defaults.ge_nom_stems_v
+    bdk_stems = sublexica.bdk_stems | defaults.compound_stems_nn #| defaults.ge_nom_stems_v
     bdk_stems.draw("bdk_stems.dot", portrait=True)
     intermediate = pynini.concat(bdk_stems, suffs1).optimize()
     intermediate.draw("intermediate.dot", portrait=True)
@@ -186,10 +186,15 @@ class TimurFst:
         self.__syms.stem_types,
         ).project().closure().optimize()
 
-    base = (tmp + inflection.inflection) * (alphabet + inflection.inflection_filter) * deko_filter.infix_filter 
+    base = (tmp + inflection.inflection)
     base.optimize().draw("base.dot", portrait=True)
+    base = base * (alphabet + inflection.inflection_filter)
+    base.optimize().draw("base1.dot", portrait=True)
+    base = base * deko_filter.infix_filter 
+    deko_filter.infix_filter.optimize().draw("infix_filter.dot", portrait=True)
+    base.optimize().draw("base2.dot", portrait=True)
     base = base * deko_filter.uplow
-    base.draw("base2.dot", portrait=True)
+    base.optimize().draw("base3.dot", portrait=True)
 
     #
     #  application of phonological rules


### PR DESCRIPTION
The derivation of deriv stems of origin `prefnativ` (lexically
prefixed stems) did not work. This commit makes the necessary
adjustments.